### PR TITLE
Avoid breaking changes by depending on a fixed rerun version

### DIFF
--- a/glomap/CMakeLists.txt
+++ b/glomap/CMakeLists.txt
@@ -65,7 +65,7 @@ set(HEADERS
 
 include(FetchContent)
 FetchContent_Declare(rerun_sdk URL
-    https://github.com/rerun-io/rerun/releases/latest/download/rerun_cpp_sdk.zip)
+    https://github.com/rerun-io/rerun/releases/download/0.17.0/rerun_cpp_sdk.zip)
 FetchContent_MakeAvailable(rerun_sdk)
 
 


### PR DESCRIPTION
CMakeLists used to depend on the "latest" version of rerun.

This caused the build to break in `rerun=0.18.0` since `Transform3D` was split